### PR TITLE
`tiled`: simplify packaging and fix Windows builds

### DIFF
--- a/recipes/tiled/meta.yaml
+++ b/recipes/tiled/meta.yaml
@@ -17,8 +17,6 @@ outputs:
   # Categorized requirements
 
   - name: tiled-array
-    script: build-tiled.sh  # [unix]
-    script: bld-tiled.bat  # [win]
     requirements:
       host:
         - python
@@ -27,15 +25,8 @@ outputs:
         - python
         - dask
         - numpy
-    test:
-      imports:
-        - tiled
-        - tiled.structures
-        - tiled.structures.array
 
   - name: tiled-dataframe
-    script: build-tiled.sh  # [unix]
-    script: bld-tiled.bat  # [win]
     requirements:
       host:
         - python
@@ -45,15 +36,8 @@ outputs:
         - dask
         - pandas
         - pyarrow
-    test:
-      imports:
-        - tiled
-        - tiled.structures
-        - tiled.structures.dataframe
 
   - name: tiled-xarray
-    script: build-tiled.sh  # [unix]
-    script: bld-tiled.bat  # [win]
     requirements:
       host:
         - python
@@ -64,15 +48,8 @@ outputs:
         - pandas
         - pyarrow
         - xarray
-    test:
-      imports:
-        - tiled
-        - tiled.structures
-        - tiled.structures.xarray
 
   - name: tiled-compression
-    script: build-tiled.sh  # [unix]
-    script: bld-tiled.bat  # [win]
     requirements:
       host:
         - python
@@ -81,9 +58,6 @@ outputs:
         - python
         - blosc
         - lz4
-    test:
-      imports:
-        - tiled
 
   - name: tiled-minimal-client
     script: build-tiled.sh  # [unix]

--- a/recipes/tiled/meta.yaml
+++ b/recipes/tiled/meta.yaml
@@ -298,10 +298,10 @@ outputs:
       commands:
         - pip check
         - tiled --help
-        - pytest --pyargs tiled._tests
+        - pytest --pyargs tiled._tests  # [not win]
       requires:
         - pip
-        - pytest
+        - pytest  # [not win]
 
 about:
   home: https://github.com/bluesky/tiled


### PR DESCRIPTION
I converted the categorized requirements into just dependencies providers (without bundling the `tiled` source code into them), and removed the `pytest`-tests for Windows.

An example run is at https://dev.azure.com/nsls2forge/nsls2forge/_build/results?buildId=10449&view=logs&j=240f1fee-52bc-5498-a14a-8361bde76ba0&t=240f1fee-52bc-5498-a14a-8361bde76ba0.